### PR TITLE
Compatibility with Cassandra 4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,19 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
 
       # Runs a single command using the runners shell
       - name: Build, unit and integration tests
-        run: mvn install
+        run: |
+
+            # temp – before 4.0.8 is released
+            git clone -b cassandra-4.0 https://github.com/apache/cassandra.git
+            cd cassandra
+            ant -Drat.skip=true -Dno-checkstyle=true -Dno-javadoc=true -Dant.gen-doc.skip=true mvn-install
+            cd -
+            
+            mvn install

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.thelastpickle.cassandra</groupId>
-    <artifactId>cassandra-zipkin-tracing</artifactId>
+    <artifactId>cassandra_4-zipkin-tracing</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
@@ -15,14 +15,14 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>3.9</version>
+            <version>4.0.8-SNAPSHOT</version> <!-- dependent on CASSANDRA-17981 -->
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <!-- the version needs to match that which is supplied in the above version of Cassandra -->
-            <version>3.0.1</version>
+            <version>3.11.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -41,6 +41,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -82,33 +88,13 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Language-level aside, make sure Java 8 types and methods aren't used -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.14</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java18</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-dependency-plugin</artifactId>
               <version>2.10</version>
               <executions>
                 <execution>
-                  <id>copy-dependencies</id>
+                  <id>copy-runtime-dependencies</id>
                   <phase>package</phase>
                   <goals>
                     <goal>copy-dependencies</goal>
@@ -116,6 +102,25 @@
                   <configuration>
                       <outputDirectory>target</outputDirectory>
                       <includeScope>runtime</includeScope>
+                  </configuration>
+                </execution>
+                <!-- hack, before 4.0.8 is released (and CASSANDRA-17981 ) -->
+                <execution>
+                  <id>copy-cassandra-jar</id>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>copy</goal>
+                  </goals>
+                  <configuration>
+                    <artifactItems>
+                      <artifactItem>
+                            <groupId>org.apache.cassandra</groupId>
+                            <artifactId>cassandra-all</artifactId>
+                            <version>4.0.8-SNAPSHOT</version> <!-- dependent on CASSANDRA-17981 -->
+                            <destFileName>apache-cassandra-4.0.7.jar</destFileName> <!-- needs to overrides docker image jar file -->
+                      </artifactItem>
+                    </artifactItems>
+                    <outputDirectory>target</outputDirectory>
                   </configuration>
                 </execution>
               </executions>

--- a/src/integration/resources/Makefile
+++ b/src/integration/resources/Makefile
@@ -3,6 +3,7 @@ all: setup test teardown
 	
 
 test:
+	docker exec -t cassandra-zipkin-tracing-tests_cassandra-01_1 nodetool status
 	docker exec -t cassandra-zipkin-tracing-tests_cassandra-00_1 cqlsh -e "create keyspace test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};"
 	sleep 2
 	docker exec -t cassandra-zipkin-tracing-tests_cassandra-00_1 cqlsh -e "create table test.test (one text primary key, two text);"

--- a/src/integration/resources/Makefile
+++ b/src/integration/resources/Makefile
@@ -3,18 +3,23 @@ all: setup test teardown
 	
 
 test:
-	docker exec -t resources_cassandra-0_1 cqlsh -e "create keyspace test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};"
-	docker exec -t resources_cassandra-0_1 cqlsh -e "create table test.test (one text primary key, two text);"
-	docker exec -t resources_cassandra-0_1 cqlsh -e "tracing on; insert into test.test (one , two ) VALUES ( 'one', 'two');" || true
-	docker exec -t resources_cassandra-0_1 cqlsh -e "tracing on; select * from test.test;" || true
-	docker exec -t resources_zipkin-0_1 wget "http://localhost:9411/api/v2/traces?limit=10" -q --header "accept: application/json" -O - | grep -q "parsing insert"
-	docker exec -t resources_zipkin-0_1 wget "http://localhost:9411/api/v2/traces?limit=10" -q --header "accept: application/json" -O - | grep -q "parsing select"
+	docker exec -t cassandra-zipkin-tracing-tests_cassandra-00_1 cqlsh -e "create keyspace test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};"
+	sleep 2
+	docker exec -t cassandra-zipkin-tracing-tests_cassandra-00_1 cqlsh -e "create table test.test (one text primary key, two text);"
+	sleep 2
+	docker exec -t cassandra-zipkin-tracing-tests_cassandra-00_1 cqlsh -e "tracing on; insert into test.test (one , two ) VALUES ( 'one', 'two');" || true
+	sleep 2
+	docker exec -t cassandra-zipkin-tracing-tests_cassandra-00_1 cqlsh -e "tracing on; select * from test.test;" || true
+	sleep 2
+	docker exec -t cassandra-zipkin-tracing-tests_zipkin-00_1 wget "http://localhost:9411/api/v2/traces?limit=10" -q --header "accept: application/json" -O - | jq .
+	docker exec -t cassandra-zipkin-tracing-tests_zipkin-00_1 wget "http://localhost:9411/api/v2/traces?limit=10" -q --header "accept: application/json" -O - | grep -q "parsing insert"
+	docker exec -t cassandra-zipkin-tracing-tests_zipkin-00_1 wget "http://localhost:9411/api/v2/traces?limit=10" -q --header "accept: application/json" -O - | grep -q "parsing select"
+	docker exec -t cassandra-zipkin-tracing-tests_zipkin-00_1 wget "http://localhost:9411/api/v2/traces?limit=10" -q --header "accept: application/json" -O - | grep -q "range_req message received from"
 
 
 setup:
 	docker-compose up --build -d
-	docker-compose ps
-	sleep 20
+	while (! docker-compose ps | grep -q "cassandra-00") || docker-compose ps | grep -q -e "(health: starting)" -e "running (starting)" || docker-compose ps | grep -q "Exit" ; do docker-compose ps ; echo "waiting 10s…" ; sleep 10 ; done
 
 teardown:
 	docker-compose down

--- a/src/integration/resources/docker-compose.yml
+++ b/src/integration/resources/docker-compose.yml
@@ -3,89 +3,76 @@ version: '3.8'
 services:
   zipkin-0:
     image: openzipkin/zipkin
+    container_name: cassandra-zipkin-tracing-tests_zipkin-00_1
     ports:
         - 9411:9411
 
-  cassandra-0:
+  cassandra-00:
     build:
         context: .
         dockerfile: integration-cassandra.docker
-    image: cstar:integration-cassandra
+    image: cassandra-zipkin-tracing:integration-cassandra
+    container_name: cassandra-zipkin-tracing-tests_cassandra-00_1
     environment:
         CASSANDRA_ENDPOINT_SNITCH: "GossipingPropertyFileSnitch"
+        CASSANDRA_CLUSTER_NAME: cluster1
         CASSANDRA_DC: dc1
         CASSANDRA_RACK: r1
         CASSANDRA_NUM_TOKENS: 16
     volumes:
          - ../../../.:/cassandra-zipkin-tracing
     healthcheck:
-        test: ["CMD", "nc", "-z", "cassandra-0", "9042"]
-        interval: 30s
+        test: ["CMD", "nc", "-z", "cassandra-00", "9042"]
+        interval: 5s
         timeout: 10s
-        retries: 5
+        retries: 60
 
-  cassandra-1:
+  cassandra-01:
     build:
         context: .
         dockerfile: integration-cassandra.docker
-    image: cstar:integration-cassandra
+    image: cassandra-zipkin-tracing:integration-cassandra
+    container_name: cassandra-zipkin-tracing-tests_cassandra-01_1
     depends_on:
-        - cassandra-0
+        - cassandra-00
     environment:
-        CASSANDRA_SEEDS: cassandra-0
+        CASSANDRA_SEEDS: cassandra-00
         CASSANDRA_ENDPOINT_SNITCH: "GossipingPropertyFileSnitch"
+        CASSANDRA_CLUSTER_NAME: cluster1
         CASSANDRA_DC: dc1
         CASSANDRA_RACK: r2
         CASSANDRA_NUM_TOKENS: 16
-        CASSANDRA_WAIT_ON: cassandra-0
+        CASSANDRA_WAIT_ON: cassandra-00
+        JVM_EXTRA_OPTS: '-Dcassandra.consistent.rangemovement=false -Dcassandra.ring_delay_ms=2000'
     volumes:
          - ../../../.:/cassandra-zipkin-tracing
     healthcheck:
-        test: ["CMD", "nc", "-z", "cassandra-1", "9042"]
-        interval: 30s
+        test: ["CMD", "nc", "-z", "cassandra-01", "9042"]
+        interval: 5s
         timeout: 10s
-        retries: 5
+        retries: 60
 
-# not enough memory to do this locally
-#  cassandra-2:
+#  cassandra-02:
 #    build:
-#        context: .
-#        dockerfile: integration-cassandra.docker
-#    image: cstar:integration-cassandra
+#       context: .
+#       dockerfile: integration-cassandra.docker
+#    image: cassandra-zipkin-tracing:integration-cassandra
+#    container_name: cassandra-zipkin-tracing-tests_cassandra-02_1
 #    depends_on:
-#        - cassandra-1
+#       - cassandra-00
 #    environment:
-#        CASSANDRA_ENDPOINT_SNITCH: "GossipingPropertyFileSnitch"
-#        CASSANDRA_DC: dc2
-#        CASSANDRA_RACK: r1
-#        CASSANDRA_NUM_TOKENS: 16
-#        CASSANDRA_WAIT_ON: cassandra-1
+#       CASSANDRA_SEEDS: cassandra-00
+#       CASSANDRA_ENDPOINT_SNITCH: "GossipingPropertyFileSnitch"
+#       CASSANDRA_CLUSTER_NAME: cluster1
+#       CASSANDRA_DC: dc2
+#       CASSANDRA_RACK: r1
+#       CASSANDRA_NUM_TOKENS: 16
+#       CASSANDRA_WAIT_ON: cassandra-00
+#       JVM_EXTRA_OPTS: '-Dcassandra.consistent.rangemovement=false -Dcassandra.ring_delay_ms=2000'
 #    volumes:
 #         - ../../../.:/cassandra-zipkin-tracing
 #    healthcheck:
-#        test: ["CMD", "nc", "-z", "cassandra-0", "9042"]
-#        interval: 30s
-#        timeout: 10s
-#        retries: 5
-#
-#  cassandra-3:
-#    build:
-#        context: .
-#        dockerfile: integration-cassandra.docker
-#    image: cstar:integration-cassandra
-#    depends_on:
-#        - cassandra-2
-#    environment:
-#        CASSANDRA_SEEDS: cassandra-0
-#        CASSANDRA_ENDPOINT_SNITCH: "GossipingPropertyFileSnitch"
-#        CASSANDRA_DC: dc2
-#        CASSANDRA_RACK: r2
-#        CASSANDRA_NUM_TOKENS: 16
-#        CASSANDRA_WAIT_ON: cassandra-2
-#    volumes:
-#         - ../../../.:/cassandra-zipkin-tracing
-#    healthcheck:
-#        test: ["CMD", "nc", "-z", "cassandra-0", "9042"]
-#        interval: 30s
-#        timeout: 10s
-#        retries: 5
+#       test: ["CMD", "nc", "-z", "cassandra-02", "9042"]
+#       interval: 5s
+#       timeout: 10s
+#       retries: 60

--- a/src/integration/resources/docker-compose.yml
+++ b/src/integration/resources/docker-compose.yml
@@ -18,7 +18,6 @@ services:
         CASSANDRA_CLUSTER_NAME: cluster1
         CASSANDRA_DC: dc1
         CASSANDRA_RACK: r1
-        CASSANDRA_NUM_TOKENS: 16
     volumes:
          - ../../../.:/cassandra-zipkin-tracing
     healthcheck:
@@ -41,7 +40,6 @@ services:
         CASSANDRA_CLUSTER_NAME: cluster1
         CASSANDRA_DC: dc1
         CASSANDRA_RACK: r2
-        CASSANDRA_NUM_TOKENS: 16
         CASSANDRA_WAIT_ON: cassandra-00
         JVM_EXTRA_OPTS: '-Dcassandra.consistent.rangemovement=false -Dcassandra.ring_delay_ms=2000'
     volumes:
@@ -66,7 +64,6 @@ services:
 #       CASSANDRA_CLUSTER_NAME: cluster1
 #       CASSANDRA_DC: dc2
 #       CASSANDRA_RACK: r1
-#       CASSANDRA_NUM_TOKENS: 16
 #       CASSANDRA_WAIT_ON: cassandra-00
 #       JVM_EXTRA_OPTS: '-Dcassandra.consistent.rangemovement=false -Dcassandra.ring_delay_ms=2000'
 #    volumes:

--- a/src/integration/resources/integration-cassandra.docker
+++ b/src/integration/resources/integration-cassandra.docker
@@ -1,10 +1,13 @@
-FROM cassandra:3.11.8
+FROM cassandra:4.0.7
 
-RUN apt-get update && apt-get install -y wait-for-it
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y wait-for-it netcat
 
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
+ENV MAX_HEAP_SIZE 500M
+ENV HEAP_NEWSIZE 100M
 
 ENV CASSANDRA_HOME /opt/cassandra
 ENV CASSANDRA_CONF /etc/cassandra
@@ -15,9 +18,9 @@ RUN sed -i '1s;^;export PATH=/opt/cassandra/bin:$PATH\n;' /etc/bash.bashrc
 RUN sed -i '1s;^;export JAVA_HOME=/opt/java/openjdk\n;' /etc/bash.bashrc
 
 # install cassandra-zipkin-tracing
-RUN echo "# cassandra-zipkin-tracing" >> $CASSANDRA_CONF/jvm.options
-RUN echo "-Dcassandra.custom_tracing_class=com.thelastpickle.cassandra.tracing.ZipkinTracing" >> $CASSANDRA_CONF/jvm.options
-RUN echo "-DZipkinTracing.httpCollectorHost=zipkin-0" >> $CASSANDRA_CONF/jvm.options
+RUN echo "# cassandra-zipkin-tracing" >> $CASSANDRA_CONF/jvm-server.options
+RUN echo "-Dcassandra.custom_tracing_class=com.thelastpickle.cassandra.tracing.ZipkinTracing" >> $CASSANDRA_CONF/jvm-server.options
+RUN echo "-DZipkinTracing.httpCollectorHost=zipkin-0" >> $CASSANDRA_CONF/jvm-server.options
 
 
 EXPOSE 22

--- a/src/main/java/com/thelastpickle/cassandra/tracing/ZipkinTraceState.java
+++ b/src/main/java/com/thelastpickle/cassandra/tracing/ZipkinTraceState.java
@@ -21,10 +21,10 @@ import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.ServerSpan;
 import com.twitter.zipkin.gen.Annotation;
 import com.twitter.zipkin.gen.Span;
+import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.tracing.TraceState;
 import org.apache.cassandra.tracing.Tracing;
 
-import java.net.InetAddress;
 import java.util.Deque;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -49,7 +49,7 @@ final class ZipkinTraceState extends TraceState
 
     public ZipkinTraceState(
             Brave brave,
-            InetAddress coordinator,
+            InetAddressAndPort coordinator,
             UUID sessionId,
             Tracing.TraceType traceType,
             ServerSpan serverSpan)

--- a/src/test/resources/cassandra.yaml
+++ b/src/test/resources/cassandra.yaml
@@ -509,10 +509,6 @@ listen_address: localhost
 # used to allow/disallow connections from peer nodes.
 # internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
 
-# Whether to start the native transport server.
-# Please note that the address on which the native transport is bound is the
-# same as the rpc_address. The port however is different and specified below.
-start_native_transport: true
 # port for the CQL native transport to listen for clients on
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
 native_transport_port: 9042
@@ -541,95 +537,6 @@ native_transport_port: 9042
 # The maximum number of concurrent client connections per source ip.
 # The default is -1, which means unlimited.
 # native_transport_max_concurrent_connections_per_ip: -1
-
-# Whether to start the thrift rpc server.
-start_rpc: false
-
-# The address or interface to bind the Thrift RPC service and native transport
-# server to.
-#
-# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
-# to a single address, IP aliasing is not supported.
-#
-# Leaving rpc_address blank has the same effect as on listen_address
-# (i.e. it will be based on the configured hostname of the node).
-#
-# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
-# set broadcast_rpc_address to a value other than 0.0.0.0.
-#
-# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-#
-# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
-# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
-# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
-# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
-rpc_address: localhost
-# rpc_interface: eth1
-# rpc_interface_prefer_ipv6: false
-
-# port for Thrift to listen for clients on
-rpc_port: 9160
-
-# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
-# be set to 0.0.0.0. If left blank, this will be set to the value of
-# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
-# be set.
-# broadcast_rpc_address: 1.2.3.4
-
-# enable or disable keepalive on rpc/native connections
-rpc_keepalive: true
-
-# Cassandra provides two out-of-the-box options for the RPC Server:
-#
-# sync  -> One thread per thrift connection. For a very large number of clients, memory
-#          will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
-#          per thread, and that will correspond to your use of virtual memory (but physical memory
-#          may be limited depending on use of stack space).
-#
-# hsha  -> Stands for "half synchronous, half asynchronous." All thrift clients are handled
-#          asynchronously using a small number of threads that does not vary with the amount
-#          of thrift clients (and thus scales well to many clients). The rpc requests are still
-#          synchronous (one thread per active request). If hsha is selected then it is essential
-#          that rpc_max_threads is changed from the default value of unlimited.
-#
-# The default is sync because on Windows hsha is about 30% slower.  On Linux,
-# sync/hsha performance is about the same, with hsha of course using less memory.
-#
-# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
-# of an o.a.c.t.TServerFactory that can create an instance of it.
-rpc_server_type: sync
-
-# Uncomment rpc_min|max_thread to set request pool size limits.
-#
-# Regardless of your choice of RPC server (see above), the number of maximum requests in the
-# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
-# RPC server, it also dictates the number of clients that can be connected at all).
-#
-# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
-# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
-# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
-#
-# rpc_min_threads: 16
-# rpc_max_threads: 2048
-
-# uncomment to set socket buffer sizes on rpc connections
-# rpc_send_buff_size_in_bytes:
-# rpc_recv_buff_size_in_bytes:
-
-# Uncomment to set socket buffer size for internode communication
-# Note that when setting this, the buffer size is limited by net.core.wmem_max
-# and when not setting it it is defined by net.ipv4.tcp_wmem
-# See:
-# /proc/sys/net/core/wmem_max
-# /proc/sys/net/core/rmem_max
-# /proc/sys/net/ipv4/tcp_wmem
-# /proc/sys/net/ipv4/tcp_wmem
-# and: man tcp
-# internode_send_buff_size_in_bytes:
-# internode_recv_buff_size_in_bytes:
-
-# Frame size for thrift (maximum message length).
-thrift_framed_transport_size_in_mb: 15
 
 # Set to true to have Cassandra create a hard link to each sstable
 # flushed or streamed locally in a backups/ subdirectory of the
@@ -835,19 +742,6 @@ dynamic_snitch_reset_interval_in_ms: 600000
 # 0.2 means Cassandra would continue to prefer the static snitch values
 # until the pinned host was 20% worse than the fastest.
 dynamic_snitch_badness_threshold: 0.1
-
-# request_scheduler -- Set this to a class that implements
-# RequestScheduler, which will schedule incoming client requests
-# according to the specific policy. This is useful for multi-tenancy
-# with a single Cassandra cluster.
-# NOTE: This is specifically for requests from the client and does
-# not affect inter node communication.
-# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
-# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
-# client requests to a node with a separate queue for each
-# request_scheduler_id. The scheduler is further customized by
-# request_scheduler_options as described below.
-request_scheduler: org.apache.cassandra.scheduler.NoScheduler
 
 # Scheduler Options vary based on the type of scheduler
 # NoScheduler - Has no options


### PR DESCRIPTION
Depends on CASSANDRA-17981 to restore internode tracing, because the new messaging system (CASSANDRA-15066) does not permit custom keys/entries anymore.